### PR TITLE
feat: update soft delete & add new API permanent delete, create service, getAll service

### DIFF
--- a/src/features/account/accountController.ts
+++ b/src/features/account/accountController.ts
@@ -17,6 +17,7 @@ export class AccountController {
       const job_position_name = req.query.job_position_name as string;
       const employment_status_name = req.query.employment_status_name as string;
       const get_all = req.query.get_all as string;
+      const deleted = req.query.deleted as string;
       const employees = await AccountService.getAllEmployees({
         company_branch_id,
         hasResigned,
@@ -26,6 +27,7 @@ export class AccountController {
         job_position_name,
         employment_status_name,
         get_all,
+        deleted,
       });
       res.status(200).json({
         success: true,
@@ -185,44 +187,41 @@ export class AccountController {
     }
   }
 
-  static async deleteEmployee(req: Request, res: Response, next: NextFunction) {
+  static async softDeleteEmployee(req: Request, res: Response, next: NextFunction) {
     try {
       const employee_id = req.params.employee_id;
       const company_branch_id = req.params.company_branch_id;
-      const deletingEmployee = await AccountService.deleteEmployee({
+      const deletingEmployee = await AccountService.softDeleteEmployee({
         company_branch_id,
         employee_id,
       });
       res.status(200).json({
         success: true,
         data: deletingEmployee,
-        message: "Employee deleted successfully",
+        message: "Employee soft deleted successfully",
       });
     } catch (error) {
       next(error);
     }
   }
 
-  // static async softDeleteEmployee(
-  //   req: Request,
-  //   res: Response,
-  //   next: NextFunction
-  // ) {
-  //   try {
-  //     const { employee_id, company_branch_id } = req.body;
-  //     const softDeleteEmployee = await AccountService.softDeleteEmployee({
-  //       employee_id,
-  //       company_branch_id,
-  //     });
-  //     return res.status(200).json({
-  //       success: true,
-  //       data: softDeleteEmployee,
-  //       message: "Successfully soft delete employee",
-  //     });
-  //   } catch (error) {
-  //     next(error);
-  //   }
-  // }
+  static  async deleteEmployeeFromDatabase(req: Request, res: Response, next: NextFunction) {
+    try {
+      const employee_id = req.params.employee_id;
+      const company_branch_id = req.params.company_branch_id;
+      const deletingEmployee = await AccountService.deleteEmployeeFromDatabase({
+        company_branch_id,
+        employee_id,
+      });
+      res.status(200).json({
+        success: true,
+        data: deletingEmployee,
+        message: "Employee deleted permanently successfully",
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
 
   static async employeeResign(req: Request, res: Response, next: NextFunction) {
     try {

--- a/src/features/account/accountModel.ts
+++ b/src/features/account/accountModel.ts
@@ -15,6 +15,7 @@ export type GetEmployeeRequest = {
   job_position_name?: string | undefined;
   employment_status_name?: string | undefined;
   get_all?: string | undefined;
+  deleted?: string | undefined;
 };
 
 export type GetAllEmployeeResponse = Employee[];
@@ -94,6 +95,7 @@ export type DeleteRequest = {
 export type DeleteResponse = {
   employee_id: string;
   first_name: string;
+  last_name: string;
 };
 
 export type ResignRequest = DeleteRequest;

--- a/src/features/account/accountRoute.ts
+++ b/src/features/account/accountRoute.ts
@@ -43,12 +43,16 @@ accountRoute.patch('/:company_branch_id/resigned', [
   JWTMiddleware.verifyToken,
   AccountController.employeeResign,
 ]);
-// accountRoute.patch('/branch/:company_branch_id/employee/:employee_id', AccountController.softDeleteEmployee);
 
-// Delete an employee
-accountRoute.delete('/branch/:company_branch_id/employee/:employee_id', [
+// soft Delete an employee, set deleted_at to current date and still keep the data
+accountRoute.delete('/branch/:company_branch_id/employee/:employee_id/softDelete', [
   JWTMiddleware.verifyToken,
-  AccountController.deleteEmployee,
+  AccountController.softDeleteEmployee,
 ]);
 
+// Literally Delete from database
+accountRoute.delete('/branch/:company_branch_id/employee/:employee_id/deletePermanent', [
+  JWTMiddleware.verifyToken,
+  AccountController.deleteEmployeeFromDatabase,
+]);
 export default accountRoute;


### PR DESCRIPTION
soft delete for account is make hasResigned true and add a Date to delete_at, delete permanent is remove from db, create account service can make an account when there are same email in the same company branch with account has been deleted, and the last is get all employee adding filter job position name, employment status, and deleted If deleted equals to true, return deleted account only.